### PR TITLE
Send aligned chunks to the device

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "author": "Juan Cruz Viotti <juanchiviotti@gmail.com>",
   "license": "MIT",
   "optionalDependencies": {
-		"diskpart": "^1.0.0"
+   "diskpart": "^1.0.0"
   },
   "devDependencies": {
     "chai": "~1.10.0",
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "async": "^0.9.0",
+    "chunking-streams": "0.0.8",
     "lodash-contrib": "^241.4.14"
   }
 }


### PR DESCRIPTION
For some reason, piping directly to Windows 10 results in EINVAL errors
because data is not aligned properly.
